### PR TITLE
Fix spelling error in deadbolt

### DIFF
--- a/zwavegeneric/README.md
+++ b/zwavegeneric/README.md
@@ -49,7 +49,7 @@ All door locks that follow the Z-Wave door lock specification.
 
 Known to work:
 
-* Deadbold - Schlage (Allegion) Touchscreen Door lock BE469
-* Deadbold - Schlage (Allegion) ZWavePlus Touchscreen Door lock BE469ZWP
+* Deadbolt - Schlage (Allegion) Touchscreen Door lock BE469
+* Deadbolt - Schlage (Allegion) ZWavePlus Touchscreen Door lock BE469ZWP
 
 


### PR DESCRIPTION
Changing 'deadbold' to deadbolt twice